### PR TITLE
cmake find_package support for partial libs

### DIFF
--- a/libs/boost/1.73.0/package.py
+++ b/libs/boost/1.73.0/package.py
@@ -35,7 +35,7 @@ uuid = "libs.boost"
 
 
 def commands():
-    env.CMAKE_MODULE_PATH.append("{root}/cmake")
+    env.CMAKE_PREFIX_PATH.append("{root}/lib/cmake")
 
     if building:
         env.PKG_CONFIG_PATH.append("{root}/lib/pkgconfig")

--- a/libs/expat/2.2.8/package.py
+++ b/libs/expat/2.2.8/package.py
@@ -34,7 +34,7 @@ uuid = "libs.expat"
 
 
 def commands():
-    env.CMAKE_MODULE_PATH.append("{root}/cmake")
+    env.CMAKE_PREFIX_PATH.append("{root}/lib/cmake/{name}-{version}")
 
     if building:
         env.PKG_CONFIG_PATH.append("{root}/lib/pkgconfig")

--- a/libs/oiio/2.2.15/package.py
+++ b/libs/oiio/2.2.15/package.py
@@ -42,7 +42,7 @@ uuid = "libs.oiio"
 
 
 def commands():
-    env.CMAKE_MODULE_PATH.append("{root}/cmake")
+    env.CMAKE_PREFIX_PATH.append("{root}/lib/cmake/OpenImageIO")
 
     if building:
         env.PKG_CONFIG_PATH.append("{root}/lib/pkgconfig")

--- a/libs/openexr/2.4.3/package.py
+++ b/libs/openexr/2.4.3/package.py
@@ -36,7 +36,8 @@ uuid = "libs.openexr"
 
 
 def commands():
-    env.CMAKE_MODULE_PATH.append("{root}/cmake")
+    env.CMAKE_PREFIX_PATH.append("{root}/lib/cmake/IlmBase")
+    env.CMAKE_PREFIX_PATH.append("{root}/lib/cmake/OpenEXR")
 
     if building:
         env.PKG_CONFIG_PATH.append("{root}/lib/pkgconfig")

--- a/libs/pybind11/2.6.2/package.py
+++ b/libs/pybind11/2.6.2/package.py
@@ -36,7 +36,7 @@ uuid = "libs.pybind11"
 
 
 def commands():
-    env.CMAKE_MODULE_PATH.append("{root}/cmake")
+    env.CMAKE_PREFIX_PATH.append("{root}/share/cmake/{name}")
 
     if building:
         env.PKG_CONFIG_PATH.append("{root}/lib/pkgconfig")

--- a/libs/tbb/2020.2/CMakeLists.txt
+++ b/libs/tbb/2020.2/CMakeLists.txt
@@ -13,7 +13,7 @@ set(make_args -j$ENV{REZ_BUILD_THREAD_COUNT} VERBOSE=1)
 
 if(${REZ_BUILD_INSTALL})
     set(install_cmd python build/build.py
-        --prefix $ENV{REZ_BUILD_INSTALL_PATH} --install-devel)
+        --prefix $ENV{REZ_BUILD_INSTALL_PATH} --install-devel --install-libs)
 else()
     set(install_cmd echo "skip install step")
 endif()

--- a/libs/tbb/2020.2/package.py
+++ b/libs/tbb/2020.2/package.py
@@ -33,5 +33,7 @@ uuid = "libs.tbb"
 
 
 def commands():
+    env.CMAKE_PREFIX_PATH.append("{root}/lib/cmake/{name}")
+
     if building:
         env.PKG_CONFIG_PATH.append("{root}/lib/pkgconfig")

--- a/libs/tbb/2021.2.0/package.py
+++ b/libs/tbb/2021.2.0/package.py
@@ -33,5 +33,7 @@ uuid = "libs.tbb"
 
 
 def commands():
+    env.CMAKE_PREFIX_PATH.append("{root}/lib/cmake/TBB")
+
     if building:
         env.PKG_CONFIG_PATH.append("{root}/lib/pkgconfig")

--- a/libs/yamlcpp/0.6.3/package.py
+++ b/libs/yamlcpp/0.6.3/package.py
@@ -34,7 +34,7 @@ uuid = "libs.yamlcpp"
 
 
 def commands():
-    env.CMAKE_MODULE_PATH.append("{root}/cmake")
+    env.CMAKE_PREFIX_PATH.append("{root}/lib/cmake/yaml-cpp")
 
     if building:
         env.PKG_CONFIG_PATH.append("{root}/lib/pkgconfig")

--- a/softwares/cmake/3.20.4/package.py
+++ b/softwares/cmake/3.20.4/package.py
@@ -40,6 +40,7 @@ def commands():
     env.C_INCLUDE_PATH.append("{root}/include")
     env.CPLUS_INCLUDE_PATH.append("{root}/include")
     env.LIBRARY_PATH.append("{root}/lib")
+    env.CMAKE_MODULE_PATH.append("{root}/share/cmake-3.20/Modules")
 
     if building:
         env.PKG_CONFIG_PATH.append("{root}/lib/pkgconfig")


### PR DESCRIPTION
Cmake config mode support so user can use `find_package` in their cmake file like this:
`find_package(TBB REQUIRED COMPONENTS tbb)`

When you cmake your project, it should under rez-env `yourlib` enviroment like:
```
rez-env tbb-2020.2
cmake .. -DCMAKE_BUILD_TYPE=Release
```